### PR TITLE
AP_HAL_RP: issue #34: Add dual USB CDC support to USBSerialDriver

### DIFF
--- a/libraries/AP_HAL_RP/AP_HAL_RP_Private.h
+++ b/libraries/AP_HAL_RP/AP_HAL_RP_Private.h
@@ -15,6 +15,7 @@
 #include "WSPIDevice.h"
 #include "Storage.h"
 #include "UARTDriver.h"
+#include "USBSerialDriver.h"
 #include "Util.h"
 #include "Flash.h"
 #include "DSP.h"

--- a/libraries/AP_HAL_RP/HAL_RP_Class.cpp
+++ b/libraries/AP_HAL_RP/HAL_RP_Class.cpp
@@ -10,7 +10,6 @@
 #include <AP_HAL_Empty/AP_HAL_Empty_Private.h>
 //#include <AP_Filesystem/AP_Filesystem_RP2350.h>
 #include "pico/stdlib.h"
-#include "pico/stdio_usb.h"
 
 using namespace RP;
 
@@ -24,7 +23,8 @@ using namespace RP;
 
 static UARTDriver serial0Driver(uart0, UART0_TX, UART0_RX, 0, true);
 static UARTDriver serial1Driver(uart1, UART1_TX, UART1_RX, 1);
-static USBSerialDriver usbConsoleDriver;
+static USBSerialDriver usbConsoleDriver(0);
+static USBSerialDriver usbMavlinkDriver(1);
 
 #if defined(HAL_SERIAL2_DRIVER_ENABLED) && HAL_SERIAL2_DRIVER_ENABLED == 1
 static UARTDriver serial2Driver;
@@ -96,7 +96,11 @@ HAL_RP::HAL_RP() :
 #else
         nullptr,
 #endif
-        nullptr,            /* no SERIAL4 */
+#if defined(HAL_SERIAL4_DRIVER_ENABLED) && HAL_SERIAL4_DRIVER_ENABLED == 1
+        &usbMavlinkDriver,
+#else
+        nullptr,
+#endif
         nullptr,            /* no SERIAL5 */
         nullptr,            /* no SERIAL6 */
         nullptr,            /* no SERIAL7 */
@@ -167,22 +171,12 @@ void HAL_RP::run(int argc, char* const argv[], Callbacks* callbacks) const
     (void)argc;
     (void)argv;
 
-    console->begin(115200);
+#if defined(HAL_RP_CONSOLE_USB_CDC) && HAL_RP_CONSOLE_USB_CDC == 0
+    if (console) {
+        console->begin(115200);
+    }
+#endif // HAL_RP_CONSOLE_USB_CDC == 0
 
-#if defined(HAL_RP_CONSOLE_USB_CDC) && HAL_RP_CONSOLE_USB_CDC == 1
-    const uint32_t usb_wait_start_ms = AP_HAL::millis();
-    while (!stdio_usb_connected() && (AP_HAL::millis() - usb_wait_start_ms) < HAL_RP_USB_CDC_CONNECT_TIMEOUT_MS) {
-        sleep_ms(10);
-    }
-#if HAL_RP_USB_CDC_FALLBACK_TO_UART0
-    if (!stdio_usb_connected()) {
-        serial0Driver.begin(115200);
-        serial0Driver.printf("USB CDC not detected after %lu ms, falling back to UART0 console\n",
-                             (unsigned long)HAL_RP_USB_CDC_CONNECT_TIMEOUT_MS);
-        const_cast<HAL_RP*>(this)->console = &serial0Driver;
-    }
-#endif
-#endif
 #if defined(HAL_NAND_FLASH_ENABLED) && HAL_NAND_FLASH_ENABLED == 1
     this->get_nand_pio()->init(NAND_FLASH_IO_BASE, NAND_FLASH_SCLK, NAND_FLASH_CS);
 #endif
@@ -209,6 +203,12 @@ LED* HAL_RP::get_led_driver() const {
 #else
     return nullptr;
 #endif
+}
+
+void HAL_RP::init_usb_cdc_drivers() const
+{
+    usbConsoleDriver.begin(115200);
+    usbMavlinkDriver.begin(115200);
 }
 
 const AP_HAL::HAL& AP_HAL::get_HAL() {

--- a/libraries/AP_HAL_RP/HAL_RP_Class.h
+++ b/libraries/AP_HAL_RP/HAL_RP_Class.h
@@ -11,4 +11,5 @@ public:
 
     RP::NAND_PIO_Driver* get_nand_pio() const;
     RP::LED* get_led_driver() const;
+    void init_usb_cdc_drivers() const;
 };

--- a/libraries/AP_HAL_RP/Scheduler.cpp
+++ b/libraries/AP_HAL_RP/Scheduler.cpp
@@ -1,5 +1,6 @@
 #include "AP_HAL_RP/Scheduler.h"
 #include "AP_Math/AP_Math.h"
+#include "AP_HAL_RP_Private.h"
 #include <cstdlib>
 #include "pico/stdlib.h"
 #include "pico/bootrom.h"
@@ -76,6 +77,14 @@ void Scheduler::init() {
         DEV_PRINTF("FAILED to create task _io_task\n");
     }
     vTaskCoreAffinitySet(_io_task_handle, CORE_1);
+
+    if (xTaskCreate(_usb_device_task, "Ardu_USB", USB_SS, this, USB_PRIO, &_usb_device_task_handle) == pdPASS) {
+        DEV_PRINTF("OK created task _usb_device_task\n");
+    }
+    else {
+        DEV_PRINTF("FAILED to create task _usb_device_task\n");
+    }
+    vTaskCoreAffinitySet(_usb_device_task_handle, CORE_1);
 
 #if 0
     // Create a task for storage on Core 1
@@ -167,6 +176,23 @@ void Scheduler::_uart_task(void *pvParameters) {
         if (hal.console) {
             hal.console->_timer_tick();
         }
+        sched->delay(1);
+    }
+}
+
+void Scheduler::_usb_device_task(void *pvParameters)
+{
+    Scheduler *sched = (Scheduler *)pvParameters;
+
+    while (!sched->_initialized) {
+        sched->delay(10);
+    }
+
+    const HAL_RP& rp_hal = static_cast<const HAL_RP&>(hal);
+    rp_hal.init_usb_cdc_drivers();
+
+    while (true) {
+        RP::USBSerialDriver::backend_task();
         sched->delay(1);
     }
 }

--- a/libraries/AP_HAL_RP/Scheduler.h
+++ b/libraries/AP_HAL_RP/Scheduler.h
@@ -40,6 +40,7 @@ public:
     static const int MIN_PRIO     = tskIDLE_PRIORITY + 1;
     static const int MAIN_PRIO    = MAX_PRIO - 2;   // Main loop (Core 0)
     static const int TIMER_PRIO   = MAX_PRIO;       // Timers (must be higher than MAIN for accuracy)
+    static const int USB_PRIO     = MAX_PRIO;       // USB CDC
     static const int UART_PRIO    = MAX_PRIO - 1;   // UART (fast output, but below the timer)
     static const int SPI_PRIORITY = MAX_PRIO - 3;   // Fast sensors (IMU)
     static const int RCOUT_PRIO   = MAX_PRIO - 15;  // PWM output
@@ -58,12 +59,14 @@ public:
     static const int RCOUT_SS     = 512;  // 2 KB
     static const int IO_SS        = 1024; // 4 KB
     static const int STORAGE_SS   = 1024; // 4 KB
+    static const int USB_SS       = 1024; // 4 KB
 
 private:
     static void _main_task(void *pvParameters);
     static void _timer_task(void *pvParameters);
     static void _io_task(void *pvParameters);
     static void _uart_task(void *pvParameters);
+    static void _usb_device_task(void *pvParameters);
 
     static void thread_create_trampoline(void *ctx);
 
@@ -82,6 +85,7 @@ private:
     TaskHandle_t _timer_task_handle;
     TaskHandle_t _io_task_handle;
     TaskHandle_t _uart_task_handle;
+    TaskHandle_t _usb_device_task_handle;
 
     AP_HAL::HAL::Callbacks *_callbacks;
 

--- a/libraries/AP_HAL_RP/UARTDriver.cpp
+++ b/libraries/AP_HAL_RP/UARTDriver.cpp
@@ -218,7 +218,7 @@ uint32_t UARTDriver::txspace() {
     }
     return _writebuf.space();
 }
-
+#if 0
 void UARTDriver::vprintf(const char *fmt, va_list ap) {
     if (!_initialized) {
         return;
@@ -238,10 +238,23 @@ void UARTDriver::vprintf(const char *fmt, va_list ap) {
         _write((const uint8_t *)buffer, len);
     }
 }
+#endif
+void UARTDriver::vprintf(const char *fmt, va_list ap) {
+    if (!_initialized) {
+        return;
+    }
+
+    char buffer[256];
+
+    int n = hal.util->vsnprintf(buffer, sizeof(buffer), fmt, ap);
+    if (n > 0) {
+        size_t len = MIN((size_t)n, sizeof(buffer)-1);
+        _write((const uint8_t *)buffer, len);
+    }
+}
 
 size_t UARTDriver::write(uint8_t c) {
-    if (!_initialized) return 0;
-    return _writebuf.write(&c, 1);
+    return _write(&c, 1);
 }
 
 size_t UARTDriver::write(const uint8_t *buffer, size_t size) {

--- a/libraries/AP_HAL_RP/USBSerialDriver.cpp
+++ b/libraries/AP_HAL_RP/USBSerialDriver.cpp
@@ -1,26 +1,215 @@
 #include "USBSerialDriver.h"
-
-#include "pico/stdio.h"
-#include "pico/stdio_usb.h"
+#include <AP_Math/AP_Math.h>
+#include "pico/platform.h"
+#include "pico/unique_id.h"
+#include "tusb.h"
+#include <array>
 
 using namespace RP;
 
 extern const AP_HAL::HAL& hal;
 
-USBSerialDriver::USBSerialDriver() :
+namespace {
+
+constexpr uint8_t USB_CDC_PORT_COUNT = 2;
+constexpr uint8_t USB_CONFIGURATION_INDEX = 1;
+constexpr uint8_t USB_STRING_INDEX_MANUFACTURER = 1;
+constexpr uint8_t USB_STRING_INDEX_PRODUCT = 2;
+constexpr uint8_t USB_STRING_INDEX_SERIAL = 3;
+constexpr uint8_t USB_STRING_INDEX_CDC0 = 4;
+constexpr uint8_t USB_STRING_INDEX_CDC1 = 5;
+constexpr uint8_t USB_CDC_DATA_EP_SIZE = 64;
+constexpr uint8_t USB_CDC_NOTIFICATION_EP_SIZE = 8;
+
+static_assert(CFG_TUD_CDC == USB_CDC_PORT_COUNT, "USB CDC descriptor count must match USB_CDC_PORT_COUNT");
+
+enum usb_interface_index : uint8_t {
+    ITF_NUM_CDC0 = 0,
+    ITF_NUM_CDC0_DATA,
+    ITF_NUM_CDC1,
+    ITF_NUM_CDC1_DATA,
+    ITF_NUM_TOTAL
+};
+
+enum usb_endpoint_number : uint8_t {
+    EPNUM_CDC0_NOTIF = 0x81,
+    EPNUM_CDC0_OUT   = 0x02,
+    EPNUM_CDC0_IN    = 0x82,
+    EPNUM_CDC1_NOTIF = 0x83,
+    EPNUM_CDC1_OUT   = 0x04,
+    EPNUM_CDC1_IN    = 0x84,
+};
+
+constexpr uint8_t USB_DESCRIPTOR_LENGTH = TUD_CONFIG_DESC_LEN + (CFG_TUD_CDC * TUD_CDC_DESC_LEN);
+
+const tusb_desc_device_t usb_device_descriptor = []() {
+    tusb_desc_device_t descriptor{};
+    descriptor.bLength = sizeof(tusb_desc_device_t);
+    descriptor.bDescriptorType = TUSB_DESC_DEVICE;
+    descriptor.bcdUSB = 0x0200;
+    descriptor.bDeviceClass = TUSB_CLASS_MISC;
+    descriptor.bDeviceSubClass = MISC_SUBCLASS_COMMON;
+    descriptor.bDeviceProtocol = MISC_PROTOCOL_IAD;
+    descriptor.bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE;
+    descriptor.idVendor = 0x2DAE;
+    descriptor.idProduct = 0x1010;
+    descriptor.bcdDevice = 0x0100;
+    descriptor.iManufacturer = USB_STRING_INDEX_MANUFACTURER;
+    descriptor.iProduct = USB_STRING_INDEX_PRODUCT;
+    descriptor.iSerialNumber = USB_STRING_INDEX_SERIAL;
+    descriptor.bNumConfigurations = 1;
+    return descriptor;
+}();
+
+const uint8_t usb_configuration_descriptor[] = {
+    TUD_CONFIG_DESCRIPTOR(USB_CONFIGURATION_INDEX, ITF_NUM_TOTAL, 0, USB_DESCRIPTOR_LENGTH,
+                          TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC0, USB_STRING_INDEX_CDC0, EPNUM_CDC0_NOTIF, USB_CDC_NOTIFICATION_EP_SIZE,
+                       EPNUM_CDC0_OUT, EPNUM_CDC0_IN, USB_CDC_DATA_EP_SIZE),
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC1, USB_STRING_INDEX_CDC1, EPNUM_CDC1_NOTIF, USB_CDC_NOTIFICATION_EP_SIZE,
+                       EPNUM_CDC1_OUT, EPNUM_CDC1_IN, USB_CDC_DATA_EP_SIZE),
+};
+
+const char *const usb_string_descriptors[] = {
+    nullptr,
+    "ArduPilot",
+    "ArduPilot Dual CDC",
+    nullptr,
+    "ArduPilot Console",
+    "ArduPilot USB Serial",
+};
+
+uint16_t usb_string_descriptor_buffer[32];
+
+class USBSerialManager {
+public:
+    static USBSerialManager &instance()
+    {
+        static USBSerialManager manager;
+        return manager;
+    }
+
+    void register_driver(USBSerialDriver *driver, uint8_t interface_num)
+    {
+        if (interface_num < _drivers.size()) {
+            _drivers[interface_num] = driver;
+        }
+    }
+
+    void init()
+    {
+        if (_initialized) {
+            return;
+        }
+
+        tusb_rhport_init_t dev_init{};
+        dev_init.role = TUSB_ROLE_DEVICE;
+        dev_init.speed = TUSB_SPEED_AUTO;
+        tusb_init(0, &dev_init);
+        _initialized = true;
+    }
+
+    void task()
+    {
+        if (!_initialized) {
+            return;
+        }
+        tud_task();
+    }
+
+    bool connected(uint8_t interface_num) const
+    {
+        return interface_num < _line_state_dtr.size() && _line_state_dtr[interface_num];
+    }
+
+    void line_state_changed(uint8_t interface_num, bool dtr)
+    {
+        if (interface_num < _line_state_dtr.size()) {
+            _line_state_dtr[interface_num] = dtr;
+        }
+    }
+
+    USBSerialDriver *driver(uint8_t interface_num) const
+    {
+        if (interface_num >= _drivers.size()) {
+            return nullptr;
+        }
+        return _drivers[interface_num];
+    }
+
+private:
+    bool _initialized = false;
+    std::array<USBSerialDriver *, USB_CDC_PORT_COUNT> _drivers{};
+    std::array<bool, USB_CDC_PORT_COUNT> _line_state_dtr{};
+};
+
+} // namespace
+
+extern "C" const uint8_t *tud_descriptor_device_cb(void)
+{
+    return reinterpret_cast<const uint8_t *>(&usb_device_descriptor);
+}
+
+extern "C" const uint8_t *tud_descriptor_configuration_cb(uint8_t index)
+{
+    (void)index;
+    return usb_configuration_descriptor;
+}
+
+extern "C" const uint16_t *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
+{
+    (void)langid;
+
+    uint8_t chr_count = 0;
+    if (index == 0) {
+        usb_string_descriptor_buffer[1] = 0x0409;
+        chr_count = 1;
+    } else if (index == USB_STRING_INDEX_SERIAL) {
+        char serial[2 * PICO_UNIQUE_BOARD_ID_SIZE_BYTES + 1] = {};
+        pico_get_unique_board_id_string(serial, sizeof(serial));
+        while (chr_count < (sizeof(usb_string_descriptor_buffer) / sizeof(usb_string_descriptor_buffer[0]) - 1) &&
+               serial[chr_count] != '\0') {
+            usb_string_descriptor_buffer[1 + chr_count] = serial[chr_count];
+            chr_count++;
+        }
+    } else if (index < ARRAY_SIZE(usb_string_descriptors) && usb_string_descriptors[index] != nullptr) {
+        const char *str = usb_string_descriptors[index];
+        while (chr_count < (sizeof(usb_string_descriptor_buffer) / sizeof(usb_string_descriptor_buffer[0]) - 1) &&
+               str[chr_count] != '\0') {
+            usb_string_descriptor_buffer[1 + chr_count] = str[chr_count];
+            chr_count++;
+        }
+    } else {
+        return nullptr;
+    }
+
+    usb_string_descriptor_buffer[0] = (TUSB_DESC_STRING << 8) | (2 * chr_count + 2);
+    return usb_string_descriptor_buffer;
+}
+
+extern "C" void tud_cdc_line_state_cb(uint8_t instance, bool dtr, bool rts)
+{
+    (void)rts;
+    USBSerialManager::instance().line_state_changed(instance, dtr);
+}
+
+USBSerialDriver::USBSerialDriver(uint8_t interface_num) :
+    _interface_num(interface_num),
     _baudrate(115200),
     _initialized(false),
     _readbuf{UART_RX_BUFFER_SIZE},
     _writebuf{UART_TX_BUFFER_SIZE},
     _write_mutex{}
-{}
+{
+    USBSerialManager::instance().register_driver(this, _interface_num);
+}
 
 void USBSerialDriver::_begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
 {
     _baudrate = baud;
     _readbuf.set_size(rxSpace >= 128 ? rxSpace : 128);
     _writebuf.set_size(txSpace >= 128 ? txSpace : 128);
-    stdio_usb_init();
+    USBSerialManager::instance().init();
     _initialized = true;
 }
 
@@ -29,31 +218,45 @@ void USBSerialDriver::_end()
     _initialized = false;
 }
 
+bool USBSerialDriver::is_usb_connected() const
+{
+    return USBSerialManager::instance().connected(_interface_num);
+}
+
 void USBSerialDriver::_poll_rx()
 {
     if (!_initialized) {
         return;
     }
 
-    while (true) {
-        const int ch = getchar_timeout_us(0);
-        if (ch == PICO_ERROR_TIMEOUT) {
+    while (tud_cdc_n_available(_interface_num) > 0 && _readbuf.space() > 0) {
+        uint8_t c;
+        if (tud_cdc_n_read(_interface_num, &c, 1) != 1) {
             break;
         }
-        const uint8_t c = (uint8_t)ch;
         _readbuf.write(&c, 1);
     }
 }
 
 void USBSerialDriver::_flush_tx()
 {
-    while (_writebuf.available() > 0) {
-        uint8_t c;
-        if (!_writebuf.read(&c, 1)) {
+    if (!_initialized || !tud_cdc_n_connected(_interface_num)) {
+        return;
+    }
+
+    while (_writebuf.available() > 0 && tud_cdc_n_write_available(_interface_num) > 0) {
+        uint8_t chunk[USB_CDC_DATA_EP_SIZE];
+        const uint16_t available = _writebuf.available();
+        const uint32_t usb_space = tud_cdc_n_write_available(_interface_num);
+        const uint16_t count = MIN<uint16_t>(available, MIN<uint32_t>(sizeof(chunk), usb_space));
+        if (!_writebuf.read(chunk, count)) {
             break;
         }
-        putchar_raw((char)c);
+        if (tud_cdc_n_write(_interface_num, chunk, count) != count) {
+            break;
+        }
     }
+    tud_cdc_n_write_flush(_interface_num);
 }
 
 size_t USBSerialDriver::_write(const uint8_t *buffer, size_t size)
@@ -191,4 +394,9 @@ size_t USBSerialDriver::write(uint8_t c)
 size_t USBSerialDriver::write(const uint8_t *buffer, size_t size)
 {
     return _write(buffer, size);
+}
+
+void USBSerialDriver::backend_task()
+{
+    USBSerialManager::instance().task();
 }

--- a/libraries/AP_HAL_RP/USBSerialDriver.h
+++ b/libraries/AP_HAL_RP/USBSerialDriver.h
@@ -5,7 +5,7 @@
 
 class RP::USBSerialDriver : public AP_HAL::UARTDriver {
 public:
-    USBSerialDriver();
+    explicit USBSerialDriver(uint8_t interface_num = 0);
 
     bool is_initialized() override { return _initialized; }
     bool tx_pending() override;
@@ -23,6 +23,10 @@ public:
 
     void _timer_tick() override;
 
+    bool is_usb_connected() const;
+
+    static void backend_task();
+
 protected:
     void _begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace) override;
     void _end() override;
@@ -38,6 +42,7 @@ private:
     void _poll_rx();
     void _flush_tx();
 
+    const uint8_t _interface_num;
     uint32_t _baudrate;
     bool _initialized;
     ByteBuffer _readbuf;

--- a/libraries/AP_HAL_RP/hwdef/Kolibri/hwdef.dat
+++ b/libraries/AP_HAL_RP/hwdef/Kolibri/hwdef.dat
@@ -22,10 +22,17 @@ define HAL_SERIAL3_DRIVER_ENABLED 0
 define HAL_SPI_DEVICE_DRIVER_ENABLED 0
 define HAL_I2C_DEVICE_DRIVER_ENABLED 0
 
+# USB CDC 0 is used for consose
+# USB CDC 1 is used for Mavlink
+
+# MavLink via USB CDC
+define HAL_USB_MAVLINK_SERIAL_NUM 4
+define HAL_SERIAL4_DRIVER_ENABLED 1
+
 # Debug options
 # Console transport: 0=UART (default), 1=USB CDC
 # Set to 1 to route hal.console to USB virtual COM port.
-define HAL_RP_CONSOLE_USB_CDC 0
+define HAL_RP_CONSOLE_USB_CDC 1
 
 define SCHEDDEBUG 1
 

--- a/libraries/AP_HAL_RP/hwdef/Pico2Pilot/hwdef.dat
+++ b/libraries/AP_HAL_RP/hwdef/Pico2Pilot/hwdef.dat
@@ -25,9 +25,14 @@ define HAL_I2C_DEVICE_DRIVER_ENABLED 1
 # Debug options
 # Console transport: 0=UART (default), 1=USB CDC
 # Set to 1 to route hal.console to USB virtual COM port.
-define HAL_RP_CONSOLE_USB_CDC 0
-define HAL_RP_USB_CDC_CONNECT_TIMEOUT_MS 5000
-define HAL_RP_USB_CDC_FALLBACK_TO_UART0 1
+define HAL_RP_CONSOLE_USB_CDC 1
+
+# USB CDC 0 is used for consose
+# USB CDC 1 is used for Mavlink
+
+# MavLink via USB CDC
+define HAL_USB_MAVLINK_SERIAL_NUM 4
+define HAL_SERIAL4_DRIVER_ENABLED 1
 
 define SCHEDDEBUG 1
 

--- a/libraries/AP_HAL_RP/hwdef/Pico2WPilot/hwdef.dat
+++ b/libraries/AP_HAL_RP/hwdef/Pico2WPilot/hwdef.dat
@@ -22,12 +22,17 @@ define HAL_SERIAL3_DRIVER_ENABLED 0
 define HAL_SPI_DEVICE_DRIVER_ENABLED 1
 define HAL_I2C_DEVICE_DRIVER_ENABLED 1
 
+# USB CDC 0 is used for consose
+# USB CDC 1 is used for Mavlink
+
+# MavLink via USB CDC
+define HAL_USB_MAVLINK_SERIAL_NUM 4
+define HAL_SERIAL4_DRIVER_ENABLED 1
+
 # Debug options
 # Console transport: 0=UART (default), 1=USB CDC
 # Set to 1 to route hal.console to USB virtual COM port.
-define HAL_RP_CONSOLE_USB_CDC 0
-define HAL_RP_USB_CDC_CONNECT_TIMEOUT_MS 100
-define HAL_RP_USB_CDC_FALLBACK_TO_UART0 1
+define HAL_RP_CONSOLE_USB_CDC 1
 
 define SCHEDDEBUG 1
 

--- a/libraries/AP_HAL_RP/template/CMakeLists.txt.template
+++ b/libraries/AP_HAL_RP/template/CMakeLists.txt.template
@@ -94,7 +94,8 @@ target_include_directories(AP_HAL_RP PUBLIC
 target_link_libraries(AP_HAL_RP PUBLIC
     pico_stdlib
     pico_multicore
-    pico_stdio_usb
+    pico_unique_id
+    tinyusb_device
     hardware_spi
     hardware_i2c
     hardware_dma
@@ -216,9 +217,9 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
     ${FREERTOS_KERNEL_PATH}/portable/ThirdParty/Community-Supported-Ports/GCC/RP2350_ARM_NTZ/non_secure
 )
 
-# Enable USB stdio backend for optional USB CDC console support.
-# UART stdio is disabled because AP_HAL_RP handles UART transport directly.
-pico_enable_stdio_usb(${CMAKE_PROJECT_NAME} 1)
+# AP_HAL_RP uses TinyUSB directly to expose two CDC interfaces.
+# UART stdio remains disabled because AP_HAL_RP handles UART transport directly.
+pico_enable_stdio_usb(${CMAKE_PROJECT_NAME} 0)
 pico_enable_stdio_uart(${CMAKE_PROJECT_NAME} 0)
 
 # Add the standard Pico build steps to create UF2

--- a/libraries/AP_HAL_RP/tusb_config.h
+++ b/libraries/AP_HAL_RP/tusb_config.h
@@ -1,0 +1,38 @@
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "hardware/structs/usb.h"
+
+#ifndef CFG_TUSB_MCU
+#define CFG_TUSB_MCU OPT_MCU_RP2040
+#endif
+
+#define CFG_TUD_ENABLED 1
+
+#define CFG_TUSB_RHPORT0_MODE (OPT_MODE_DEVICE | OPT_MODE_FULL_SPEED)
+#ifndef BOARD_TUD_RHPORT
+#define BOARD_TUD_RHPORT 0
+#endif
+
+#ifndef CFG_TUSB_OS
+#define CFG_TUSB_OS OPT_OS_FREERTOS
+#endif
+
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE 64
+#endif
+
+#define CFG_TUD_CDC 2
+#define CFG_TUD_CDC_RX_BUFSIZE 256
+#define CFG_TUD_CDC_TX_BUFSIZE 256
+#define CFG_TUD_CDC_EP_BUFSIZE 64
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */


### PR DESCRIPTION
## Summary

Add USD CDC driver

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

The driver uses tinyUSB library from pico-sdk to provide dual USB CDC driver.  USB CDC 0 is used as a console, USB CDC 1 is used as a Mavlink port 